### PR TITLE
Dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.15.2-0.1-A'
+version = '1.15.2-0.1.1-A'
 group = 'com.epiphany.isawedthisplayerinhalf'
 archivesBaseName = 'isawedthisplayerinhalf'
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ issueTrackerURL="https://github.com/ona-li-toki-e-jan-Epiphany-tawa-mi/ISawedThi
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 modId="swdthsplyrnhlf"
-version="1.15.2-0.1-A"
+version="1.15.2-0.1.1-A"
 displayName="I Sawed This Player In Half!"
 # A URL to query for updates for this mod. See the JSON update specification <here>
 # updateJSONURL="http://myurl.me/" #optional

--- a/src/main/resources/assets/swdthsplyrnhlf/lang/eo_eo.json
+++ b/src/main/resources/assets/swdthsplyrnhlf/lang/eo_eo.json
@@ -1,8 +1,0 @@
-{
-  "commands.swdthsplyrnhlf.offsets.get": "nanpa pi ma ante: %f, %f, %f",
-  "commands.swdthsplyrnhlf.offsets.reset": "nanpa pi ma ante li 0",
-  "commands.swdthsplyrnhlf.offsets.set.usage": "::offsets set <x> <y> <z>",
-  "commands.swdthsplyrnhlf.offsets.set.set": "ma ante li ante",
-  "commands.swdthsplyrnhlf.offsets.help": "ante e ma ante sina lon musi\nnimi ante: ::ofs",
-  "commands.swdthsplyrnhlf.offsets.usage": "::offsets (help|get|reset)>"
-}

--- a/src/main/resources/assets/swdthsplyrnhlf/lang/eo_uy.json
+++ b/src/main/resources/assets/swdthsplyrnhlf/lang/eo_uy.json
@@ -1,0 +1,8 @@
+{
+  "commands.swdthsplyrnhlf.offsets.get": "nanpa pi ma ante: %f, %f, %f",
+  "commands.swdthsplyrnhlf.offsets.reset": "nanpa pi ma ante: 0, 0, 0",
+  "commands.swdthsplyrnhlf.offsets.set.usage": "::offsets set <nanpa X> <nanpa Y> <nanpa Z>",
+  "commands.swdthsplyrnhlf.offsets.set.set": "ma ante li ante",
+  "commands.swdthsplyrnhlf.offsets.help": "li ante e ma ante sina lon musi\nnimi ante: ::ofs",
+  "commands.swdthsplyrnhlf.offsets.usage": "::offsets (help|get|reset)>"
+}


### PR DESCRIPTION
Fixed Toki Pona not showing by renaming the lang file to Esperanto's actual code. Improved translations. The dev and main branches should be merged, and a patch should be released.